### PR TITLE
Fix gh-pages deploy script for CI environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:coverage": "vitest --coverage",
     "test:ui": "vitest --ui",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "node scripts/deploy.js"
   },
   "dependencies": {
     "three": "^0.160.0"

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,25 @@
+import ghpages from 'gh-pages';
+import { execSync } from 'child_process';
+
+let repo;
+if (process.env.GITHUB_TOKEN && process.env.GITHUB_REPOSITORY) {
+  repo = `https://${process.env.GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`;
+} else {
+  try {
+    repo = execSync('git config --get remote.origin.url').toString().trim();
+  } catch {
+    // ignore
+  }
+}
+
+if (!repo) {
+  console.warn('No repository URL found. Skipping deploy.');
+  process.exit(0);
+}
+
+ghpages.publish('dist', { repo }, err => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
## Summary
- Replace direct `gh-pages` CLI call with custom deploy script
- Use `GITHUB_TOKEN`/`GITHUB_REPOSITORY` or local git remote to publish
- Skip deploy gracefully when repository URL is missing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run deploy`

------
https://chatgpt.com/codex/tasks/task_b_68b0c0e29ef4832280634cf5ae60a8a8