### PR TITLE
Add depth and tilt to block rendering

### DIFF
--- a/src/animation/BlockAnimator.ts
+++ b/src/animation/BlockAnimator.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { Block } from '../game/Block';
 import { BlockState } from '../game/BlockTypes';
 import { TweenSystem, AnimationHelpers, EasingType } from './TweenSystem';
-import { BlockDimensions, VisualTimings, VisualStyle } from '../rendering/BlockConstants';
+import { BlockDimensions, VisualTimings, VisualStyle, BlockAngles } from '../rendering/BlockConstants';
 
 // Animation state tracking for blocks
 export interface BlockAnimationState {
@@ -208,7 +208,7 @@ export class BlockAnimator {
       // Restore material properties for blocks that survive the explosion
       material.opacity = 1.0;
       mesh.scale.set(1, 1, 1);
-      mesh.rotation.set(0, 0, 0);
+      mesh.rotation.set(BlockAngles.DEFAULT_TILT_X, BlockAngles.DEFAULT_TILT_Y, 0);
       if (onComplete) onComplete();
     }, fadeDelay);
   }

--- a/src/rendering/BlockConstants.ts
+++ b/src/rendering/BlockConstants.ts
@@ -7,7 +7,7 @@ export const BlockDimensions = {
   BLOCK_WIDTH: 108,
   BLOCK_HEIGHT: 103,
   // Depth for 3D effect (in pixels)
-  BLOCK_DEPTH: 16,
+  BLOCK_DEPTH: 80,
   
   // Gap between blocks
   BLOCK_GAP: 10,
@@ -18,6 +18,13 @@ export const BlockDimensions = {
   
   // Legacy tile size for backward compatibility
   LEGACY_TILE_SIZE: 32,
+} as const;
+
+// Default rotational tilt applied to blocks for subtle 3D effect
+export const BlockAngles = {
+  // Slight forward/back tilt around X and Y axes (~5 degrees)
+  DEFAULT_TILT_X: Math.PI / 36,
+  DEFAULT_TILT_Y: -Math.PI / 36,
 } as const;
 
 // Calculate board pixel dimensions based on block dimensions

--- a/src/rendering/EnhancedBoardRenderer.ts
+++ b/src/rendering/EnhancedBoardRenderer.ts
@@ -8,7 +8,7 @@ import { AnimationManager } from '../animation/AnimationManager';
 import { AssetLoader } from '../assets/AssetLoader';
 import { PixelPerfectSpriteRenderer } from './PixelPerfectSpriteRenderer';
 import { VisualEffectsManager, MatchEventData, GarbageEventData } from '../effects/VisualEffectsManager';
-import { BlockDimensions, BoardDimensions, VisualTimings, VisualStyle, getBlockPosition, getCursorDimensions } from './BlockConstants';
+import { BlockDimensions, BoardDimensions, VisualTimings, VisualStyle, BlockAngles, getBlockPosition, getCursorDimensions } from './BlockConstants';
 import { BlockTextureManager } from './BlockTextureManager';
 
 export class EnhancedBoardRenderer {
@@ -220,6 +220,7 @@ export class EnhancedBoardRenderer {
         // Offset Z so the front face remains at z=1 (original plane position)
         const zCenter = 1 - (BlockDimensions.BLOCK_DEPTH / 2);
         mesh.position.set(pos.x, pos.y, zCenter);
+        mesh.rotation.set(BlockAngles.DEFAULT_TILT_X, BlockAngles.DEFAULT_TILT_Y, 0);
         mesh.name = `Block_${row}_${col}`;
         mesh.visible = false; // Start hidden
         // Add rim/edge highlight as child so it follows animations/rotations
@@ -385,7 +386,7 @@ export class EnhancedBoardRenderer {
           }
           // Ensure transform is reset when tile becomes empty
           mesh.userData.matchRotated = false;
-          mesh.rotation.set(0, 0, 0);
+          mesh.rotation.set(BlockAngles.DEFAULT_TILT_X, BlockAngles.DEFAULT_TILT_Y, 0);
           mesh.scale.set(1, 1, 1);
         }
       }
@@ -446,7 +447,7 @@ export class EnhancedBoardRenderer {
         mesh.userData.registeredBlock = block;
         // Reset per-mesh rotation/scale when ownership changes to avoid inheriting prior effects
         mesh.userData.matchRotated = false;
-        mesh.rotation.set(0, 0, 0);
+        mesh.rotation.set(BlockAngles.DEFAULT_TILT_X, BlockAngles.DEFAULT_TILT_Y, 0);
         mesh.scale.set(1, 1, 1);
       }
     } else {
@@ -539,7 +540,7 @@ export class EnhancedBoardRenderer {
     // Reset transform for non-animated blocks
     mesh.scale.set(1, 1, 1);
     // Ensure Y rotation is reset so previously matched tiles don't stay edge-on invisible
-    mesh.rotation.set(0, 0, 0);
+    mesh.rotation.set(BlockAngles.DEFAULT_TILT_X, BlockAngles.DEFAULT_TILT_Y, 0);
 
     // Reset opacity on all materials
     materials.forEach(mat => { if (mat) mat.opacity = 1.0; });


### PR DESCRIPTION
## Summary
- Make blocks five times deeper along the z-axis
- Apply a subtle default tilt to block meshes and preserve it after resets
- Restore default tilt after block animations

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0c60d58c883228f1373812198e742