### PR TITLE
feat: add touch controls

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ class Application {
       await this.gameEngine.initialize();
       
       // Set up game components (Phase 3 integration)
-      this.setupGame();
+      this.setupGame(canvas);
       
       this.gameEngine.start();
       
@@ -41,7 +41,7 @@ class Application {
     }
   }
   
-  private setupGame(): void {
+  private setupGame(canvas: HTMLCanvasElement): void {
     if (!this.gameEngine) return;
     
     const sceneManager = this.gameEngine.getSceneManager();
@@ -56,8 +56,8 @@ class Application {
     // Create cursor
     const cursor = new Cursor(board, EnhancedBoardRenderer.TILE_SIZE);
     
-    // Create game controller with audio system
-    const gameController = new GameController(board, cursor, audioSystem);
+    // Create game controller with audio system and canvas for pointer input
+    const gameController = new GameController(board, cursor, audioSystem, canvas);
     
     // Set up cursor in scene
     sceneManager.setCursor(cursor);

--- a/tests/unit/game/TouchControls.test.ts
+++ b/tests/unit/game/TouchControls.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Board } from '../../../src/game/Board';
+import { Cursor } from '../../../src/game/Cursor';
+import { GameController } from '../../../src/game/GameController';
+import { BlockDimensions, BoardDimensions } from '../../../src/rendering/BlockConstants';
+
+// Helper to create bounding rect
+function createRect(width: number, height: number) {
+  return {
+    left: 0,
+    top: 0,
+    right: width,
+    bottom: height,
+    width,
+    height,
+    x: 0,
+    y: 0,
+    toJSON() { return {}; }
+  } as DOMRect;
+}
+
+describe('Touch controls', () => {
+  it('moves cursor on pointerdown and swaps on click', () => {
+    const board = new Board();
+    const cursor = new Cursor(board, BlockDimensions.TILE_SIZE_Y); // same as main
+    const canvas = document.createElement('canvas');
+    canvas.width = BoardDimensions.BOARD_PIXEL_WIDTH + 200;
+    canvas.height = BoardDimensions.BOARD_PIXEL_HEIGHT + 100;
+    canvas.getBoundingClientRect = () => createRect(canvas.width, canvas.height);
+
+    const controller = new GameController(board, cursor, undefined, canvas);
+
+    // Target tile
+    const tileX = 1;
+    const tileY = 2;
+    const worldWidth = BoardDimensions.BOARD_PIXEL_WIDTH + 200;
+    const worldHeight = BoardDimensions.BOARD_PIXEL_HEIGHT + 100;
+    const boardLeft = -100 - BoardDimensions.BOARD_PIXEL_WIDTH / 2;
+    const boardBottom = -BoardDimensions.BOARD_PIXEL_HEIGHT / 2;
+    const worldX = boardLeft + tileX * BlockDimensions.TILE_SIZE_X + 1;
+    const worldY = boardBottom + tileY * BlockDimensions.TILE_SIZE_Y + 1;
+    const ndcX = worldX / (worldWidth / 2);
+    const ndcY = worldY / (worldHeight / 2);
+    const clientX = ((ndcX + 1) / 2) * canvas.width;
+    const clientY = ((1 - ndcY) / 2) * canvas.height;
+
+    (controller as unknown as { handlePointerDown: (e: PointerEvent) => void }).handlePointerDown(
+      new PointerEvent('pointerdown', { clientX, clientY })
+    );
+    expect(cursor.getTargetPosition()).toEqual({ x: tileX, y: tileY });
+
+    // Click should not throw
+    expect(() => {
+      (controller as unknown as { handleClick: (e: MouseEvent) => void }).handleClick(
+        new MouseEvent('click', { clientX, clientY })
+      );
+    }).not.toThrow();
+
+    controller.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- enable touch and mouse input via pointer events to move the cursor and trigger swaps
- wire canvas through main bootstrap so GameController can attach pointer handlers
- add unit test covering touch-based cursor positioning

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b10b4e6808832299baf85f5d1c86c4